### PR TITLE
feat: chain and smiles are mandatory

### DIFF
--- a/src/pilah/logger.py
+++ b/src/pilah/logger.py
@@ -1,12 +1,11 @@
 from datetime import datetime
 
-def log_writer(config_data,
-               pilah_version,
-               ionization_records,
-               res_w_missing_atoms,
-               res_w_incorrect_bond_length_angle,
-               total_insertion,
-               renumber_residue_map): # pragma: no cover
+def log_writer(config_data, extraction_data, ionization_records, pilah_version): # pragma: no cover
+    res_w_missing_atoms = extraction_data["res_w_missing_atoms"]
+    res_w_incorrect_bond_length_angle = extraction_data["res_w_incorrect_bond_length_angle"]
+    total_insertion = extraction_data["total_insertion"]
+    renumber_residue_map = extraction_data["renumber_residue_map"]
+    
     now = datetime.now().strftime('%Y%m%d_%H%M%S')
     log_txt = f"PiLAH version: {pilah_version}\n\n"
     log_txt += "----- PiLAH Configuration -----\n\n"

--- a/src/pilah/parser.py
+++ b/src/pilah/parser.py
@@ -1,20 +1,24 @@
 from configparser import ConfigParser
+import sys
 
 from rich import print
 
 
-options = [
-    # mandatory
+mandatory_opts = [
     "input",
     "ligand_id",
     "protein_out",
     "ligand_out",
-    # optional
+    "protein_chain",
+    "ligand_chain",
+    "ligand_smiles",
+]
+
+optional_opts = [
+    "ligand_seq_num",
     "ligand_image",
     "image_size",
     "include_metal",
-    "chain",
-    "ligand_smiles",
     "pkai_model",
     "ph",
     "ptreshold"
@@ -32,7 +36,14 @@ class Config(ConfigParser):
         self.read_string("[pxpc]\n" + text)
         self.data = dict(self["pxpc"])
 
-        for key in self.data.keys():
+        data_keys = self.data.keys()
+        for key in data_keys:
+            options = mandatory_opts + optional_opts
             if key not in options:
                 print(f"Warning: '{key}' option is not recognized")
+        
+        for option in mandatory_opts:
+            if option not in data_keys:
+                sys.exit(f"Missing mandatory option: {option}")
+
         

--- a/src/pilah/pilah.py
+++ b/src/pilah/pilah.py
@@ -24,12 +24,7 @@ def run(config_file: str):
     
     ligand_pdb_block = extraction_data["ligand"]
     protein_pdb_block = extraction_data["protein"]
-    res_w_missing_atoms = extraction_data["res_w_missing_atoms"]
-    res_w_incorrect_bond_length_angle = extraction_data["res_w_incorrect_bond_length_angle"]
-    total_insertion = extraction_data["total_insertion"]
-    renumber_residue_map = extraction_data["renumber_residue_map"]
     ligand_mol, ligand_with_Hs = process_ligand(config.data, ligand_pdb_block)
-
     
     protein_protonation_results = process_protein(config.data, protein_pdb_block)
     protein_with_Hs, ionization_records = protein_protonation_results
@@ -43,13 +38,7 @@ def run(config_file: str):
     mol_writer(ligand_with_Hs, ligand_out)
     mol_writer(protein_with_Hs_renamed, protein_out, ionization_records, receptor=True)
 
-    log_writer(config.data,
-               pilah_version,
-               ionization_records,
-               res_w_missing_atoms,
-               res_w_incorrect_bond_length_angle,
-               total_insertion,
-               renumber_residue_map)
+    log_writer(config.data, extraction_data, ionization_records, pilah_version)
 
     if "ligand_image" in config.data.keys():
         ligand_image = config.data["ligand_image"]

--- a/src/pilah/protonate.py
+++ b/src/pilah/protonate.py
@@ -13,12 +13,11 @@ def process_ligand(data: dict, ligand_block: str):
     It will return ligand in protonated and unprotonated form (for image generation)
     """
     ligand_mol = Chem.MolFromPDBBlock(ligand_block)
-    ligand_smiles = Chem.MolToSmiles(ligand_mol)
-    true_smiles = data.get("ligand_smiles", ligand_smiles)
+    ligand_smiles = data["ligand_smiles"]
     pH = float(data.get("ph", 7.4))
 
     dimorphite_args = {
-        "smiles": true_smiles,
+        "smiles": ligand_smiles,
         "min_ph": pH,
         "max_ph": pH,
         "pka_precision": 0


### PR DESCRIPTION
Split chain option into `protein_chain` and `ligand_chain` options, and both of them are mandatory (rather than optional). This is because there are times when protein and its corresponding ligand were placed in different chain. Also, making the protein and ligand chain explicit make it less error prone.

SMILES is also mandatory, because on many occasion RDKit unable to assign the correct bond orders when the 3D structure of ligands were provided.