### PR TITLE
chore: add Openbabel data and binary

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,10 @@
 pyinstaller src/pilah/pilah.py \
 --name "pilah" \
 --onefile \
+--add-data="${CONDA_PREFIX}/share/openbabel/*/*:Openbabel/data/" \
+--add-binary="${CONDA_PREFIX}/lib/openbabel/*/mol2format.so:Openbabel/" \
+--add-binary="${CONDA_PREFIX}/lib/openbabel/*/pdbformat.so:Openbabel/" \
+--runtime-hook=pyi_rth_obdata.py \
 --add-data "src/pilah/dimorphite_dl/site_substructures.smarts:pilah/dimorphite_dl" \
 --add-data "src/pilah/pKAI/models/*.pt:pilah/pKAI/models" \
 --add-data "src/pilah/meeko/data/*.*:pilah/meeko/data" \

--- a/pyi_rth_obdata.py
+++ b/pyi_rth_obdata.py
@@ -1,0 +1,10 @@
+import os
+import sys
+
+
+pyinstaller_temp_dir = sys._MEIPASS
+ob_temp_dir = os.path.join(pyinstaller_temp_dir, "Openbabel")
+
+os.environ["BABEL_DATADIR"] = os.path.join(ob_temp_dir, 'data')
+os.environ["BABEL_LIBDIR"] = ob_temp_dir
+os.environ["PATH"] = ob_temp_dir + ";" + os.environ["PATH"]

--- a/src/pilah/extract.py
+++ b/src/pilah/extract.py
@@ -340,7 +340,6 @@ def extract(data):
                                    altloc_list)
 
     pdbio.save(protein_handle, residue_filter)
-    pdbio.save("test.pdb", residue_filter)
     if residue_filter.res_w_missing_atoms or residue_filter.res_w_incorrect_bond_length_angle:
         display_removed_residues(residue_filter)
     protein_handle.seek(0)


### PR DESCRIPTION
Fix the error when writing mol2 because the Openbabel data can not be loaded.