### PR TITLE
fix: ease prolin smarts pattern

### DIFF
--- a/src/pilah/extract.py
+++ b/src/pilah/extract.py
@@ -41,7 +41,7 @@ residue_smarts_dict = {
     "LYS": Chem.MolFromSmarts("[CH2X4][CH2X4][CH2X4][CH2X4][NX4+,NX3+0]"),
     "MET": Chem.MolFromSmarts("[CH2X4][CH2X4][SX2][CH3X4]"),
     "PHE": Chem.MolFromSmarts("[CH2X4][cX3]1[cX3H][cX3H][cX3H][cX3H][cX3H]1"),
-    "PRO": Chem.MolFromSmarts("N1[CX4H]([CH2][CH2][CH2]1)[CX3](=[OX1])[O,N]"),
+    "PRO": Chem.MolFromSmarts("N1[CX4H]([CH2][CH2][CH2]1)[CX3](=[OX1])"),
     "SER": Chem.MolFromSmarts("[CH2X4][OX2H]"),
     "THR": Chem.MolFromSmarts("[CHX4]([CH3X4])[OX2H]"),
     "TRP": Chem.MolFromSmarts("[CH2X4][cX3]1[cX3H][nX3H][cX3]2[cX3H][cX3H][cX3H][cX3H][cX3]12"),

--- a/src/pilah/writer.py
+++ b/src/pilah/writer.py
@@ -124,7 +124,6 @@ def mol_writer(mol, filename, ionization_records=None, receptor=False):
         if receptor:
             with NamedTemporaryFile() as temp_pdb_file:
                 pdb_block = Chem.MolToPDBBlock(mol)
-                Chem.MolToPDBFile(mol, "check.pdb")
                 pdb_block_renamed_residue = ""
                 for line in pdb_block.splitlines():
                     if ("ATOM" not in line) and ("HETATM" not in line):


### PR DESCRIPTION
When PRO have missing residue on its C term side the old SMARTS pattern is not good enough to classify it as a healthy residue, so I ease the pattern.